### PR TITLE
Purge unused words on generated git branch naming

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -113,7 +113,17 @@ const grabCommitTitle = async () => {
       const unusedEnglishWords = ['the', 'a', 'an', 'to', 'for', 'and', 'but', 'or', 'on', 'in', 'with', 'is', 'are', 'of', 'by', 'at', 'from', 'as', 'that', 'this', 'it', 'its', 'be', 'was', 'were', 'which'];
 
       // Build branch name
-      let titleForBranchName = issueTitle.toLowerCase().replaceAll(new RegExp(`\\b(${unusedEnglishWords.join('|')})\\b`, 'g'), '').replaceAll(/\s/g, '-').replaceAll(':', '-').replaceAll(',', '-').replaceAll('/', '-').replaceAll('"', '').replaceAll("'", '').replaceAll('\\', '-').replaceAll(/\-{2,}/g, '-');
+      let titleForBranchName = issueTitle
+        .toLowerCase()
+        .replaceAll(new RegExp(`\\b(${unusedEnglishWords.join('|')})\\b`, 'g'), '')
+        .replaceAll(/\s/g, '-')
+        .replaceAll(':', '-')
+        .replaceAll(',', '-')
+        .replaceAll('/', '-')
+        .replaceAll('"', '')
+        .replaceAll("'", '')
+        .replaceAll('\\', '-')
+        .replaceAll(/\-{2,}/g, '-');
 
       document.getElementById('branch-text').innerText = `${issueTypeName}/${issueId}-${titleForBranchName}`;
     }


### PR DESCRIPTION
```
➜  grab-git-infos git:(adds-word-parsing) node

Welcome to Node.js v18.20.4.
Type ".help" for more information.
> const unusedEnglishWords = ['the', 'a', 'an', 'to', 'for', 'and', 'but', 'or', 'on', 'in', 'with', 'is', 'are', 'of', 'by', 'at', 'from', 'as', 'that', 'this', 'it', 'its', 'be', 'was', 'were', 'which'];
undefined
> console.log(unusedEnglishWords)
[
  'the',  'a',     'an',   'to',
  'for',  'and',   'but',  'or',
  'on',   'in',    'with', 'is',
  'are',  'of',    'by',   'at',
  'from', 'as',    'that', 'this',
  'it',   'its',   'be',   'was',
  'were', 'which'
]
undefined
> const issueTitle = "enhancement/#2793-delete-transmitter-logs-older-than-3-months-on-qualif-and-dev"
undefined
> let titleForBranchTest = issueTitle.toLowerCase().replaceAll(new RegExp(`\\b(${unusedEnglishWords.join('|')})\\b`, 'g'), '').replaceAll(/\s/g, '-').replaceAll(':', '-').replaceAll(',', '-').replaceAll('/', '-').replaceAll('"', '').replaceAll("'", '').replaceAll('\\', '-').replaceAll(/\-{2,}/g, '-');
undefined
> console.log(titleForBranchTest)
enhancement-#2793-delete-transmitter-logs-older-than-3-months-qualif-dev
undefined
```